### PR TITLE
fix(docs): horizontal overflow in preview on mobile devices

### DIFF
--- a/apps/docs/src/components/PreviewComponent.tsx
+++ b/apps/docs/src/components/PreviewComponent.tsx
@@ -67,19 +67,20 @@ export const PreviewComponent = forwardRef<PreviewComponentType, PreviewComponen
         <Tabs.Content className={cn("rounded-lg", theme)} value="preview">
           <div
             ref={previewRef}
-            className={cn(
-              "preview not-prose dark:bg-wg-gray-950 relative flex min-h-[300px] w-full items-center justify-center rounded-lg border border-surface-100 bg-background p-10 text-sm text-foreground shadow-wg-xs",
-              {
+            className="preview not-prose dark:bg-wg-gray-950 relative flex w-full items-center justify-center rounded-lg border border-surface-100 bg-background text-sm text-foreground shadow-wg-xs"
+          >
+            <div
+              className={cn("flex min-h-[300px] w-full items-center overflow-x-auto p-10", {
                 "items-center": align === "center",
                 "items-start": align === "start",
                 "items-end": align === "end",
-              }
-            )}
-          >
-            <div className="block w-full text-center">
-              <Suspense fallback={<SuspenseFallback />}>
-                <Preview />
-              </Suspense>
+              })}
+            >
+              <div className="mx-auto block w-full min-w-fit text-center">
+                <Suspense fallback={<SuspenseFallback />}>
+                  <Preview />
+                </Suspense>
+              </div>
             </div>
 
             <Button


### PR DESCRIPTION
There is a horizontal overflow in the preview section of some components on mobile screens. This PR fixes it.

I have re-checked all the component previews on desktops and mobile layouts and these changes work the best while retaining the same previews of components as before. The `align` prop of `PreviewComponent` also continues to work in the same way.

Comparison of before / after the changes:

https://github.com/lmsqueezy/wedges/assets/21107799/25a0c3c7-f732-4ee5-a8d7-c88ac1f35983

