### PR TITLE
FIX: Docs: Update Next Install template location

### DIFF
--- a/apps/docs/src/content/installation/nextjs.mdx
+++ b/apps/docs/src/content/installation/nextjs.mdx
@@ -34,13 +34,13 @@ To create a fresh Next.js project with Wedges pre-configured, run the following 
 
     <Tabs.Content value="npm">
         ```bash
-        npx create-next-app -e https://github.com/lmsqueezy/wedges/templates/next-app-template
+        npx create-next-app -e https://github.com/lmsqueezy/wedges-next-app-template
         ```
     </Tabs.Content>
 
     <Tabs.Content value="yarn">
         ```bash
-        yarn create next-app -e https://github.com/lmsqueezy/wedges/templates/next-app-template
+        yarn create next-app -e https://github.com/lmsqueezy/wedges-next-app-template
         ```
     </Tabs.Content>
 </Tabs>


### PR DESCRIPTION
The npm and yarn `create-next-app` template repository address was incorrect.