### PR TITLE
refactor: code improvements

### DIFF
--- a/.changeset/shaggy-cups-prove.md
+++ b/.changeset/shaggy-cups-prove.md
@@ -1,0 +1,5 @@
+---
+"@lemonsqueezy/wedges": patch
+---
+
+add tailwind shorthand classes where possible

--- a/.changeset/strong-bats-bake.md
+++ b/.changeset/strong-bats-bake.md
@@ -1,0 +1,5 @@
+---
+"@lemonsqueezy/wedges": patch
+---
+
+add xs screen size to the tailwind plugin

--- a/packages/wedges/src/components/Alert/Alert.tsx
+++ b/packages/wedges/src/components/Alert/Alert.tsx
@@ -181,7 +181,7 @@ const AlertBefore = React.forwardRef<
   const Component = isReactElement(children) ? Slot : "span";
 
   if (!children) {
-    return <InfoIcon className={cn("h-6 w-6 shrink-0", alertIconVariants({ color }), className)} />;
+    return <InfoIcon className={cn("size-6 shrink-0", alertIconVariants({ color }), className)} />;
   }
 
   return (

--- a/packages/wedges/src/components/Avatar/variants.ts
+++ b/packages/wedges/src/components/Avatar/variants.ts
@@ -30,13 +30,13 @@ export const avatarVariants = cva({
 export const fallbackVariants = cva({
   variants: {
     size: {
-      xxs: "h-3 w-3",
-      xs: "h-4 w-4",
-      sm: "h-5 w-5",
-      md: "h-6 w-6",
-      lg: "h-7 w-7",
-      xl: "h-8 w-8",
-      "2xl": "h-10 w-10",
+      xxs: "size-3",
+      xs: "size-4",
+      sm: "size-5",
+      md: "size-6",
+      lg: "size-7",
+      xl: "size-8",
+      "2xl": "size-10",
     },
   },
   defaultVariants: {

--- a/packages/wedges/src/components/Badge/variants.ts
+++ b/packages/wedges/src/components/Badge/variants.ts
@@ -63,7 +63,7 @@ export const badgeVariants = cva({
 });
 
 export const iconVariants = cva({
-  base: "h-4 w-4",
+  base: "size-4",
   variants: {
     color: {
       gray: "text-surface-400",

--- a/packages/wedges/src/components/Button/variants.ts
+++ b/packages/wedges/src/components/Button/variants.ts
@@ -106,9 +106,9 @@ export const iconVariants = cva({
       true: "text-current",
     },
     size: {
-      "xs-icon": "h-5 w-5",
-      sm: "h-5 w-5",
-      md: "h-6 w-6",
+      "xs-icon": "size-5",
+      sm: "size-5",
+      md: "size-6",
     },
   },
   compoundVariants: [

--- a/packages/wedges/src/components/Checkbox/Checkbox.tsx
+++ b/packages/wedges/src/components/Checkbox/Checkbox.tsx
@@ -146,7 +146,7 @@ const CheckboxWedges = React.forwardRef<CheckboxElement, CheckboxElementProps>(
           aria-labelledby={label ? `${elId}__label` : undefined}
           checked={checked}
           className={cn(
-            "group relative flex h-6 w-6 items-center justify-center rounded-lg text-surface-200 outline-primary transition-colors duration-100 focus:outline-0 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 [&:has([data-state=checked])_.wg-unchecked]:hidden",
+            "group relative flex size-6 items-center justify-center rounded-lg text-surface-200 outline-primary transition-colors duration-100 focus:outline-0 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 [&:has([data-state=checked])_.wg-unchecked]:hidden",
             isDisabled && "pointer-events-none text-surface-200 dark:text-surface-100",
             !isDisabled && !isIndeterminate && "hover:text-surface-300",
             !isDisabled && isIndeterminate && "text-primary",

--- a/packages/wedges/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/wedges/src/components/DropdownMenu/DropdownMenu.tsx
@@ -275,7 +275,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
     {children}
 
     <svg
-      className="ms-auto h-6 w-6 text-surface-500"
+      className="ms-auto size-6 text-surface-500"
       fill="none"
       height="24"
       viewBox="0 0 24 24"

--- a/packages/wedges/src/components/Label/Label.tsx
+++ b/packages/wedges/src/components/Label/Label.tsx
@@ -66,7 +66,7 @@ const LabelWedges = React.forwardRef<LabelElement, LabelProps>(
     }
 
     return (
-      <div className="wg-label inline-flex items-center gap-1 wg-antialiased">
+      <div className="wg-label inline-flex shrink-0 items-center gap-1 wg-antialiased">
         <LabelPrimitive.Root
           ref={ref}
           asChild={useAsChild}

--- a/packages/wedges/src/components/Loading/Loading.tsx
+++ b/packages/wedges/src/components/Loading/Loading.tsx
@@ -20,13 +20,13 @@ export const loadingVariants = cva({
       secondary: "stroke-surface-100 text-secondary",
     },
     size: {
-      xxs: "h-4 w-4",
-      xs: "h-6 w-6",
-      sm: "h-8 w-8",
-      md: "h-12 w-12 [--wg-loading-stroke-width:6px]",
-      lg: "h-14 w-14",
-      xl: "h-16 w-16",
-      xxl: "h-[88px] w-[88px]",
+      xxs: "size-4",
+      xs: "size-6",
+      sm: "size-8",
+      md: "size-12 [--wg-loading-stroke-width:6px]",
+      lg: "size-14",
+      xl: "size-16",
+      xxl: "size-[88px]",
     },
     type: {
       line: "",
@@ -56,13 +56,13 @@ const Loading = React.forwardRef<LoadingElement, LoadingProps>((props, ref) => {
 
   switch (type) {
     case "line":
-      element = <Line className="h-full w-full animate-spin will-change-transform" size={size} />;
+      element = <Line className="size-full animate-spin will-change-transform" size={size} />;
       break;
 
     case "spinner":
       element = (
         <Spinner
-          className="h-full w-full animate-[spin_.6s_ease-in-out_infinite] will-change-transform"
+          className="size-full animate-[spin_.6s_ease-in-out_infinite] will-change-transform"
           size={size}
         />
       );
@@ -71,7 +71,7 @@ const Loading = React.forwardRef<LoadingElement, LoadingProps>((props, ref) => {
     case "dots":
       element = (
         <Dots
-          className="h-full w-full animate-[spin_1.25s_linear_infinite] will-change-transform"
+          className="size-full animate-[spin_1.25s_linear_infinite] will-change-transform"
           size={size}
         />
       );

--- a/packages/wedges/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/wedges/src/components/RadioGroup/RadioGroup.tsx
@@ -162,7 +162,7 @@ const RadioGroupItem = React.forwardRef<RadioGroupItemElement, RadioGroupItemPro
           ref={ref}
           aria-labelledby={label ? `${elId}__label` : undefined}
           className={cn(
-            "group relative flex h-6 w-6 items-center justify-center rounded-full text-surface-200 outline-primary transition-colors duration-100 focus:outline-0 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 [&:has([data-state=checked])_.wg-unchecked]:hidden",
+            "group relative flex size-6 items-center justify-center rounded-full text-surface-200 outline-primary transition-colors duration-100 focus:outline-0 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 [&:has([data-state=checked])_.wg-unchecked]:hidden",
             isDisabled && "pointer-events-none text-surface-200 dark:text-surface-100",
             !isDisabled && "hover:text-surface-300 data-[state=checked]:text-primary"
           )}

--- a/packages/wedges/src/components/Switch/Switch.tsx
+++ b/packages/wedges/src/components/Switch/Switch.tsx
@@ -78,7 +78,7 @@ const Switch = React.forwardRef<SwitchElement, SwitchProps>(
         >
           <SwitchPrimitive.Thumb
             className={cn(
-              "h-3 w-3 rounded-full bg-white transition-transform duration-200 data-[state=checked]:translate-x-[14px] data-[state=unchecked]:translate-x-0.5",
+              "size-3 rounded-full bg-white transition-transform duration-200 data-[state=checked]:translate-x-[14px] data-[state=unchecked]:translate-x-0.5",
               disabled && "dark:bg-surface-200"
             )}
           />

--- a/packages/wedges/src/components/Tag/Tag.tsx
+++ b/packages/wedges/src/components/Tag/Tag.tsx
@@ -90,7 +90,7 @@ const Tag = React.forwardRef<BadgeElement, TagProps>((props, ref) => {
     <>
       {isReactElement(before)
         ? React.cloneElement(before, {
-            className: cn("h-4 w-4", before.props.className || ""),
+            className: cn("size-4", before.props.className || ""),
           })
         : before}
 
@@ -104,13 +104,13 @@ const Tag = React.forwardRef<BadgeElement, TagProps>((props, ref) => {
   const renderDeleteIcon = isReactElement(deleteIcon) ? (
     deleteIcon
   ) : (
-    <CloseIcon aria-label="Close" className="h-4 w-4" />
+    <CloseIcon aria-label="Close" className="size-4" />
   );
 
   const renderCloseButton: React.ReactElement<HTMLButtonElement> | undefined = closable ? (
     <Button
       before={renderDeleteIcon}
-      className="duration-180 h-auto w-auto p-0 text-wg-gray-400 transition-colors hover:text-wg-gray-600 focus:outline-1 dark:text-wg-white-500 dark:hover:text-wg-white-700 [&>svg]:!opacity-100"
+      className="duration-180 size-auto p-0 text-wg-gray-400 transition-colors hover:text-wg-gray-600 focus:outline-1 dark:text-wg-white-500 dark:hover:text-wg-white-700 [&>svg]:!opacity-100"
       shape="pill"
       size="xs-icon"
       variant="link"

--- a/packages/wedges/src/tw-plugin/plugin.ts
+++ b/packages/wedges/src/tw-plugin/plugin.ts
@@ -230,6 +230,9 @@ const corePlugin = (
           boxShadow: {
             ...prefixedBoxShadows,
           },
+          screens: {
+            xs: "480px",
+          },
           padding: {
             "2px": "calc(2px - var(--wg-border-width, 0px))",
             "4px": "calc(4px - var(--wg-border-width, 0px))",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4342,7 +4342,7 @@ packages:
     hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001579
-      electron-to-chromium: 1.4.641
+      electron-to-chromium: 1.4.642
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.22.2)
 
@@ -5044,8 +5044,8 @@ packages:
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  /electron-to-chromium@1.4.641:
-    resolution: {integrity: sha512-JetAF3M5Lr9hwzDe3oMmWFOydlclqt2loEljxc0AAP5NYM170sSW+F5/cn5ROBfjx5LdmzeeAgWnyAU9cjPhmA==}
+  /electron-to-chromium@1.4.642:
+    resolution: {integrity: sha512-M4+u22ZJGpk4RY7tne6W+APkZhnnhmAH48FNl8iEFK2lEgob+U5rUQsIqQhvAwCXYpfd3H20pHK/ENsCvwTbsA==}
 
   /emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}


### PR DESCRIPTION
This PR:

- Replaces Tailwind classes with Tailwind CSS shorthand classes, for example: `h-4 w-4` with `size-4`
- Introduces `xs` screen size through the Wedges Tailwind CSS plugin.