### PR TITLE
Incorrect closing tag used

### DIFF
--- a/apps/docs/public/docs/components/slider.mdx
+++ b/apps/docs/public/docs/components/slider.mdx
@@ -25,7 +25,7 @@ For more advanced usage, you can use the `Slider.Root` component to compose your
         <Slider.Range />
     </Slider.Track>
     <Slider.Thumb />
-</Avatar.Root>
+</Slider.Root>
 ```
 
 ### API Reference


### PR DESCRIPTION
In the "more advanced usage" part's example code, the closing tag for `Slider.Root` is incorrect.