### PR TITLE
Update index.mdx – Close [contribution guidelines] markdown link

### DIFF
--- a/apps/docs/public/docs/index.mdx
+++ b/apps/docs/public/docs/index.mdx
@@ -19,7 +19,7 @@ Wedges is licensed under the [MIT License](https://github.com/lmsqueezy/wedges/b
 
 ### Contributing
 
-Interested in contributing to Wedges? Awesome! Start by reviewing our [contribution guidelines](https://github.com/lmsqueezy/wedges/blob/main/CONTRIBUTING.md. We value your efforts in helping us improve Wedges.
+Interested in contributing to Wedges? Awesome! Start by reviewing our [contribution guidelines](https://github.com/lmsqueezy/wedges/blob/main/CONTRIBUTING.md). We value your efforts in helping us improve Wedges.
 
 ### Credits
 


### PR DESCRIPTION
It was missing the closing parenthesis. Just a little thing I saw 👍